### PR TITLE
Add Ability to Specify an Existing SSL Certificate 

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,17 @@ monitoring_graylog_password_secret: <Make sure this is at least 20 characters lo
 monitoring_graylog_root_password:
 ```
 
+### SSL certificates
+
+This collection uses SSL certificates from Letsencrypt. You can override this by setting `monitoring_use_certbot` value to `false` and adding the following variables:
+
+```yaml
+monitoring_use_certbot: false # Setting this to false, will require we specify the SSL certificate/keys to use
+monitoring_ssl_cert_directory: "{{ inventory_dir }}/files/ssl" # the directory to search for the certificate and key
+monitoring_ssl_cert: "certificate.pem" # filename of the certificate file
+monitoring_ssl_key: "key.pem" # filename of the key file
+```
+
 You can include the playbooks defined in this collection in your playbook as illustrated below:
 
 ```yaml

--- a/playbooks/grafana.yml
+++ b/playbooks/grafana.yml
@@ -21,5 +21,7 @@
     - role: cloudalchemy.grafana
 
     - role: onaio.monitoring.certbot
+      when:  "{{ monitoring_use_certbot | default(true) }}"
 
     - role: onaio.monitoring.nginx
+

--- a/playbooks/graylog.yml
+++ b/playbooks/graylog.yml
@@ -27,5 +27,6 @@
     - role: "Graylog2.graylog-ansible-role"
 
     - role: onaio.monitoring.certbot
+      when:  "{{ monitoring_use_certbot | default(true) }}"
 
     - role: onaio.monitoring.nginx

--- a/playbooks/vars/single-host.yml
+++ b/playbooks/vars/single-host.yml
@@ -144,6 +144,10 @@ postgresql_user_privileges:
 postgresql_backup_enabled: false
 
 # NGINX
+nginx_monitoring_ssl_cert: "{{ 'fullchain.pem' if monitoring_ssl_cert is not defined else monitoring_ssl_cert }}"
+nginx_monitoring_ssl_key: "{{ 'privkey.pem' if monitoring_ssl_key is not defined else monitoring_ssl_key }}"
+nginx_monitoring_ssl_src_path: "{{ certbot_cert_path if monitoring_ssl_cert_directory is not defined else monitoring_ssl_cert_directory }}"
+nginx_monitoring_ssl_remote_src: "{{ true if monitoring_ssl_cert_directory is not defined else false }}"
 nginx_install_method: package
 nginx_ssl_dir: "{{ nginx_dir }}/ssl/{{ site.server.server_name }}"
 nginx_grafana_https_site_name: "{{ grafana_domain }}-https"
@@ -185,12 +189,12 @@ nginx_sites:
         proxy_next_upstream: "error timeout invalid_header http_500 http_502 http_503 http_504"
       ssl:
         enabled: true
-        cert: "fullchain.pem"
-        key: "privkey.pem"
-        src_dir: "/etc/letsencrypt/live/{{ certbot_cert_name }}"
-        conf: "{{ grafana_domain }}-ssl.conf"
+        cert: "{{ nginx_monitoring_ssl_cert }}"
+        key: "{{ nginx_monitoring_ssl_key }}"
+        src_dir: "{{ nginx_monitoring_ssl_src_path }}"
         create_symlink: true
-        remote_src: false
+        remote_src: "{{ nginx_monitoring_ssl_remote_src }}"
+        conf: "{{ grafana_domain }}-ssl.conf"
         access_log_format: "{{ nginx_access_logs.0.name }}"
   - server:
       name: "{{ nginx_graylog_http_site_name }}"
@@ -220,12 +224,12 @@ nginx_sites:
         proxy_next_upstream: "error timeout invalid_header http_500 http_502 http_503 http_504"
       ssl:
         enabled: true
-        cert: "fullchain.pem"
-        key: "privkey.pem"
-        src_dir: "/etc/letsencrypt/live/{{ certbot_cert_name }}"
-        conf: "{{ graylog_domain }}-ssl.conf"
+        cert: "{{ nginx_monitoring_ssl_cert }}"
+        key: "{{ nginx_monitoring_ssl_key }}"
+        src_dir: "{{ nginx_monitoring_ssl_src_path }}"
         create_symlink: true
-        remote_src: false
+        remote_src: "{{ nginx_monitoring_ssl_remote_src }}"
+        conf: "{{ graylog_domain }}-ssl.conf"
         access_log_format: "{{ nginx_access_logs.0.name }}"
   - server:
       name: "{{ nginx_sentry_http_site_name }}"
@@ -254,12 +258,12 @@ nginx_sites:
         proxy_next_upstream: "error timeout invalid_header http_500 http_502 http_503 http_504"
       ssl:
         enabled: true
-        cert: "fullchain.pem"
-        key: "privkey.pem"
-        src_dir: "/etc/letsencrypt/live/{{ certbot_cert_name }}"
-        conf: "{{ sentry_domain }}-ssl.conf"
+        cert: "{{ nginx_monitoring_ssl_cert }}"
+        key: "{{ nginx_monitoring_ssl_key }}"
+        src_dir: "{{ nginx_monitoring_ssl_src_path }}"
         create_symlink: true
-        remote_src: false
+        remote_src: "{{ nginx_monitoring_ssl_remote_src }}"
+        conf: "{{ sentry_domain }}-ssl.conf"
         access_log_format: "{{ nginx_access_logs.0.name }}"
 nginx_enabled_sites:
   - "{{ nginx_grafana_https_site_name }}"
@@ -270,6 +274,7 @@ nginx_enabled_sites:
   - "{{ nginx_sentry_http_site_name }}"
 
 # Certbot
+certbot_cert_path: "/etc/letsencrypt/live/{{ certbot_cert_name }}"
 certbot_create_certs: true
 certbot_site_names:
   - "{{ grafana_domain }}"


### PR DESCRIPTION
To allow for cases where there is an existing SSL certificate, make using Certbot optional.